### PR TITLE
chore: add conventional-commits plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,4 +21,5 @@
  */
 
 plugins {
+    id("it.nicolasfarabegoli.conventional-commits") version "3.0.12"
 }


### PR DESCRIPTION
Add conventional-commits plugin to enforce the use of conventional commits.